### PR TITLE
Oracle for BSC supporting Pancake and 1INCH

### DIFF
--- a/contracts/OracleBSC.sol
+++ b/contracts/OracleBSC.sol
@@ -1,0 +1,446 @@
+import "@pancakeswap/pancake-swap-lib/contracts/token/BEP20/IBEP20.sol";
+import "@pancakeswap/pancake-swap-lib/contracts/token/BEP20/SafeBEP20.sol";
+import "@pancakeswap/pancake-swap-lib/contracts/utils/Address.sol";
+import "@pancakeswap/pancake-swap-lib/contracts/math/SafeMath.sol";
+import "./interface/pancakeswap/IPancakeFactory.sol";
+import "./interface/pancakeswap/IPancakePair.sol";
+import "./interface/mooniswap/IMooniFactory.sol";
+import "./interface/mooniswap/IMooniswap.sol";
+import "./Governable.sol";
+
+import "hardhat/console.sol";
+
+pragma solidity 0.6.12;
+
+contract OracleBSC is Governable {
+
+  using SafeBEP20 for IBEP20;
+  using Address for address;
+  using SafeMath for uint256;
+
+  //Addresses for factories and registries for different DEX platforms. Functions will be added to allow to alter these when needed.
+  address public pancakeFactoryAddress = 0xBCfCcbde45cE874adCB698cC183deBcF17952812;
+  address public oneInchFactoryAddress = 0xD41B24bbA51fAc0E4827b6F94C0D6DDeB183cD64;
+  uint256 public precisionDecimals = 18;
+
+  IPancakeFactory pancakeFactory = IPancakeFactory(pancakeFactoryAddress);
+  IMooniFactory oneInchFactory = IMooniFactory(oneInchFactoryAddress);
+
+  //Key tokens are used to find liquidity for any given token on Uni, Sushi and Curve.
+  address[] public keyTokens = [
+  /* 0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d, //USDC */
+  0x2170Ed0880ac9A755fd29B2688956BD959F933F8, //ETH
+  /* 0x1AF3F329e8BE154074D8769D1FFa4eE058B1DBc3, //DAI */
+  /* 0x55d398326f99059fF775485246999027B3197955, //USDT */
+  0x23396cF899Ca06c4472205fC903bDB4de249D6fC, //UST
+  0x7130d2A12B9BCbFAe4f2634d864A1Ee1Ce3Ead9c, //BTCB
+  0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56, //BUSD
+  0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c, //WBNB
+  /* 0x4BD17003473389A42DAF6a0a729f6Fdb328BbBd7, //VAI */
+  0x111111111117dC0aa78b770fA6A738034120C302 //1INCH
+  ];
+  //Pricing tokens are Key tokens with good liquidity with the defined output token on Uniswap.
+  address[] public pricingTokens = [
+  0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c, //WBNB
+  0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56, //BUSD
+  0x23396cF899Ca06c4472205fC903bDB4de249D6fC //UST
+  /* 0x55d398326f99059fF775485246999027B3197955, //USDT */
+  /* 0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d, //USDC */
+  /* 0x4BD17003473389A42DAF6a0a729f6Fdb328BbBd7, //VAI */
+  /* 0x1AF3F329e8BE154074D8769D1FFa4eE058B1DBc3  //DAI */
+  ];
+  //The defined output token is the unit in which prices of input tokens are given.
+  address public definedOutputToken = 0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56; //BUSD
+
+  modifier validKeyToken(address keyToken){
+      require(checkKeyToken(keyToken), "Not a Key Token");
+      _;
+  }
+  modifier validPricingToken(address pricingToken){
+      require(checkPricingToken(pricingToken), "Not a Pricing Token");
+      _;
+  }
+
+  event FactoryChanged(address newFactory, address oldFactory);
+  event KeyTokenAdded(address newKeyToken);
+  event PricingTokenAdded(address newPricingToken);
+  event KeyTokenRemoved(address keyToken);
+  event PricingTokenRemoved(address pricingToken);
+  event DefinedOutuptChanged(address newOutputToken, address oldOutputToken);
+
+  constructor(address _storage)
+  Governable(_storage) public {}
+
+  function changePancakeFactory(address newFactory) external onlyGovernance {
+    address oldFactory = pancakeFactoryAddress;
+    pancakeFactoryAddress = newFactory;
+    pancakeFactory = IPancakeFactory(pancakeFactoryAddress);
+    emit FactoryChanged(newFactory, oldFactory);
+  }
+  function changeOneInchFactory(address newFactory) external onlyGovernance {
+    address oldFactory = oneInchFactoryAddress;
+    oneInchFactoryAddress = newFactory;
+    oneInchFactory = IMooniFactory(oneInchFactoryAddress);
+    emit FactoryChanged(newFactory, oldFactory);
+  }
+
+  function addKeyToken(address newToken) external onlyGovernance {
+    require((checkKeyToken(newToken)==false), "Already a key token");
+    keyTokens.push(newToken);
+    emit KeyTokenAdded(newToken);
+  }
+  function addPricingToken(address newToken) public onlyGovernance validKeyToken(newToken) {
+    require((checkPricingToken(newToken)==false), "Already a pricing token");
+    pricingTokens.push(newToken);
+    emit PricingTokenAdded(newToken);
+  }
+
+  function removeKeyToken(address keyToken) external onlyGovernance validKeyToken(keyToken) {
+    uint256 i;
+    for ( i=0;i<keyTokens.length;i++) {
+      if (keyToken == keyTokens[i]){
+        break;
+      }
+    }
+    while (i<keyTokens.length-1) {
+      keyTokens[i] = keyTokens[i+1];
+      i++;
+    }
+    keyTokens.pop();
+    emit KeyTokenRemoved(keyToken);
+
+    if (checkPricingToken(keyToken)) {
+      removePricingToken(keyToken);
+    }
+  }
+  function removePricingToken(address pricingToken) public onlyGovernance validPricingToken(pricingToken) {
+    uint256 i;
+    for (i=0;i<pricingTokens.length;i++) {
+      if (pricingToken == pricingTokens[i]){
+        break;
+      }
+    }
+    while (i<pricingTokens.length-1) {
+      pricingTokens[i] = pricingTokens[i+1];
+      i++;
+    }
+    pricingTokens.pop();
+    emit PricingTokenRemoved(pricingToken);
+  }
+  function changeDefinedOutput(address newOutputToken) external onlyGovernance validKeyToken(newOutputToken) {
+    address oldOutputToken = definedOutputToken;
+    definedOutputToken = newOutputToken;
+    emit DefinedOutuptChanged(newOutputToken, oldOutputToken);
+  }
+
+  //Main function of the contract. Gives the price of a given token in the defined output token.
+  //The contract allows for input tokens to be LP tokens from Uniswap, Sushiswap, Curve and 1Inch.
+  //In case of LP token, the underlying tokens will be found and valued to get the price.
+  function getPrice(address token) external view returns (uint256) {
+    if (token == definedOutputToken) {
+      return (10**precisionDecimals);
+    }
+    bool pancakeLP;
+    bool oneInchLP;
+    (pancakeLP, oneInchLP) = isLPCheck(token);
+    uint256 priceToken;
+    uint256 tokenValue;
+    uint256 price;
+    uint256 i;
+    if (pancakeLP || oneInchLP) {
+      address[2] memory tokens;
+      uint256[2] memory amounts;
+      (tokens, amounts) = (pancakeLP)? getPancakeUnderlying(token):getOneInchUnderlying(token);
+      for (i=0;i<2;i++) {
+        priceToken = computePrice(tokens[i]);
+        if (priceToken == 0) {
+          price = 0;
+          return price;
+        }
+        tokenValue = priceToken*amounts[i]/10**precisionDecimals;
+        price = price + tokenValue;
+      }
+      return price;
+    } else {
+      return computePrice(token);
+    }
+  }
+
+  function isLPCheck(address token) public view returns(bool, bool) {
+    bool isOneInch = isOneInchCheck(token);
+    bool isPancake = isPancakeCheck(token);
+    return (isPancake, isOneInch);
+  }
+
+  //Checks if address is 1Inch LP
+  function isOneInchCheck(address token) internal view returns (bool) {
+    bool oneInchLP = oneInchFactory.isPool(token);
+    return oneInchLP;
+  }
+
+  //Checks if address is Uni or Sushi LP. This is done in two steps, because the second step seems to cause errors for some tokens.
+  //Only the first step is not deemed accurate enough, as any token could be called UNI-V2.
+  function isPancakeCheck(address token) internal view returns (bool) {
+    IPancakePair pair = IPancakePair(token);
+    IBEP20 pairToken = IBEP20(token);
+    string memory pancakeSymbol = "Cake-LP";
+    string memory symbol = pairToken.symbol();
+    if (isEqualString(symbol, pancakeSymbol)) {
+      return checkFactory(pair, pancakeFactoryAddress);
+    } else {
+      return false;
+    }
+  }
+
+  function isEqualString(string memory arg1, string memory arg2) internal view returns (bool) {
+    bool check = (keccak256(abi.encodePacked(arg1)) == keccak256(abi.encodePacked(arg2)))? true:false;
+    return check;
+  }
+
+  function checkFactory(IPancakePair pair, address compareFactory) internal view returns (bool) {
+    try pair.factory{gas: 3000}() returns (address factory) {
+      bool check = (factory == compareFactory)? true:false;
+      return check;
+    } catch {
+      return false;
+    }
+  }
+
+  //Get underlying tokens and amounts for Uni/Sushi LPs
+  function getPancakeUnderlying(address token) public view returns (address[2] memory, uint256[2] memory) {
+    IPancakePair pair = IPancakePair(token);
+    IBEP20 pairToken = IBEP20(token);
+    address[2] memory tokens;
+    uint256[2] memory amounts;
+    tokens[0] = pair.token0();
+    tokens[1] = pair.token1();
+    uint256 token0Decimals = IBEP20(tokens[0]).decimals();
+    uint256 token1Decimals = IBEP20(tokens[1]).decimals();
+    uint256 supplyDecimals = IBEP20(token).decimals();
+    (uint256 reserve0, uint256 reserve1,) = pair.getReserves();
+    uint256 totalSupply = pairToken.totalSupply();
+    if (reserve0 == 0 || reserve1 == 0 || totalSupply == 0) {
+      amounts[0] = 0;
+      amounts[1] = 0;
+      return (tokens, amounts);
+    }
+    amounts[0] = reserve0*10**(supplyDecimals-token0Decimals+precisionDecimals)/totalSupply;
+    amounts[1] = reserve1*10**(supplyDecimals-token1Decimals+precisionDecimals)/totalSupply;
+    return (tokens, amounts);
+  }
+
+  //Get underlying tokens and amounts for 1Inch LPs
+  function getOneInchUnderlying(address token) public view returns (address[2] memory, uint256[2] memory) {
+    IMooniswap pair = IMooniswap(token);
+    address[2] memory tokens;
+    uint256[2] memory amounts;
+    tokens[0] = pair.token0();
+    tokens[1] = pair.token1();
+    uint256 token0Decimals = (tokens[0]==address(0))? 18:IBEP20(tokens[0]).decimals();
+    uint256 token1Decimals = IBEP20(tokens[1]).decimals();
+    uint256 supplyDecimals = IBEP20(token).decimals();
+    uint256 reserve0 = pair.getBalanceForRemoval(tokens[0]);
+    uint256 reserve1 = pair.getBalanceForRemoval(tokens[1]);
+    uint256 totalSupply = pair.totalSupply();
+    if (reserve0 == 0 || reserve1 == 0 || totalSupply == 0) {
+      amounts[0] = 0;
+      amounts[1] = 0;
+      return (tokens, amounts);
+    }
+    amounts[0] = reserve0*10**(supplyDecimals-token0Decimals+precisionDecimals)/totalSupply;
+    amounts[1] = reserve1*10**(supplyDecimals-token1Decimals+precisionDecimals)/totalSupply;
+
+    //1INCH uses ETH, instead of WETH in pools. For further calculations we continue with WETH instead.
+    //ETH will always be the first in the pair, so no need to check tokens[1]
+    if (tokens[0] == address(0)) {
+      tokens[0] = 0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c;
+    }
+    return (tokens, amounts);
+  }
+
+  //General function to compute the price of a token vs the defined output token.
+  function computePrice(address token) public view returns (uint256) {
+    uint256 price;
+    if (token == definedOutputToken) {
+      price = 10**precisionDecimals;
+    } else if (token == address(0)) {
+      price = 0;
+    } else {
+      (address keyToken, bool pancake) = getLargestPool(token,keyTokens);
+      uint256 priceVsKeyToken;
+      uint256 keyTokenPrice;
+      if (keyToken == address(0)) {
+        price = 0;
+      } else if (pancake) {
+        priceVsKeyToken = getPriceVsTokenPancake(token,keyToken);
+        keyTokenPrice = getKeyTokenPrice(keyToken);
+        price = priceVsKeyToken*keyTokenPrice/10**precisionDecimals;
+      } else {
+        priceVsKeyToken = getPriceVsToken1Inch(token,keyToken);
+        keyTokenPrice = getKeyTokenPrice(keyToken);
+        price = priceVsKeyToken*keyTokenPrice/10**precisionDecimals;
+      }
+    }
+    return (price);
+  }
+
+  //Checks the results of the different largest pool functions and returns the largest.
+  function getLargestPool(address token, address[] memory tokenList) public view returns (address, bool) {
+    (address pancakeKeyToken, uint256 pancakeLiquidity) = getPancakeLargestPool(token, tokenList);
+    (address oneInchKeyToken, uint256 oneInchLiquidity) = get1InchLargestPool(token, tokenList);
+    if (pancakeLiquidity > oneInchLiquidity) {
+      return (pancakeKeyToken, true);
+    } else {
+      return (oneInchKeyToken, false);
+    }
+  }
+
+  //Gives the Uniswap pool with largest liquidity for a given token and a given tokenset (either keyTokens or pricingTokens)
+  function getPancakeLargestPool(address token, address[] memory tokenList) internal view returns (address, uint256) {
+    uint256 largestPoolSize = 0;
+    address largestKeyToken;
+    uint256 poolSize;
+    uint256 i;
+    for (i=0;i<tokenList.length;i++) {
+      address pairAddress = pancakeFactory.getPair(token,tokenList[i]);
+      if (pairAddress!=address(0)) {
+        poolSize = getPancakePoolSize(pairAddress, token);
+      } else {
+        poolSize = 0;
+      }
+      if (poolSize > largestPoolSize) {
+        largestPoolSize = poolSize;
+        largestKeyToken = tokenList[i];
+      }
+    }
+    return (largestKeyToken, largestPoolSize);
+  }
+
+  function getPancakePoolSize(address pairAddress, address token) internal view returns(uint256) {
+    IPancakePair pair = IPancakePair(pairAddress);
+    address token0 = pair.token0();
+    (uint112 poolSize0, uint112 poolSize1,) = pair.getReserves();
+    uint256 poolSize = (token==token0)? poolSize0:poolSize1;
+    return poolSize;
+  }
+
+  //Gives the Uniswap pool with largest liquidity for a given token and a given tokenset (either keyTokens or pricingTokens)
+  function get1InchLargestPool(address token, address[] memory tokenList) internal view returns (address, uint256) {
+    uint256 largestPoolSize = 0;
+    address largestKeyToken;
+    uint256 poolSize;
+    uint256 i;
+    for (i=0;i<tokenList.length;i++) {
+      address pairAddress = oneInchFactory.pools(token,tokenList[i]);
+      if (pairAddress!=address(0)) {
+        poolSize = get1InchPoolSize(pairAddress, token);
+      } else {
+        poolSize = 0;
+      }
+      if (poolSize > largestPoolSize) {
+        largestPoolSize = poolSize;
+        largestKeyToken = tokenList[i];
+      }
+    }
+    return (largestKeyToken, largestPoolSize);
+  }
+
+  function get1InchPoolSize(address pairAddress, address token) internal view returns(uint256) {
+    IMooniswap pair = IMooniswap(pairAddress);
+    address token0 = pair.token0();
+    address token1 = pair.token1();
+    uint256 poolSize0;
+    uint256 poolSize1;
+
+    try pair.getBalanceForRemoval(token0) returns (uint256 poolSize) {
+      poolSize0 = poolSize;
+    } catch {
+      poolSize0 = 0;
+    }
+
+    try pair.getBalanceForRemoval(token1) returns (uint256 poolSize) {
+      poolSize1 = poolSize;
+    } catch {
+      poolSize1 = 0;
+    }
+
+    if (token0 == address(0)) {
+      token0 = 0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c;
+    }
+    uint256 poolSize = (token==token0)? poolSize0:poolSize1;
+    return poolSize;
+  }
+
+  //Generic function giving the price of a given token vs another given token on Uniswap.
+  function getPriceVsTokenPancake(address token0, address token1) internal view returns (uint256) {
+    address pairAddress = pancakeFactory.getPair(token0,token1);
+    IPancakePair pair = IPancakePair(pairAddress);
+    (uint256 reserve0, uint256 reserve1,) = pair.getReserves();
+    uint256 token0Decimals = IBEP20(token0).decimals();
+    uint256 token1Decimals = IBEP20(token1).decimals();
+    uint256 price;
+    if (token0 == pair.token0()) {
+      price = (reserve1*10**(token0Decimals-token1Decimals+precisionDecimals))/reserve0;
+    } else {
+      price = (reserve0*10**(token0Decimals-token1Decimals+precisionDecimals))/reserve1;
+    }
+    return price;
+  }
+
+  //Generic function giving the price of a given token vs another given token on Sushiswap.
+  function getPriceVsToken1Inch(address token0, address token1) internal view returns (uint256) {
+    address pairAddress = oneInchFactory.pools(token0,token1);
+    IMooniswap pair = IMooniswap(pairAddress);
+    uint256 reserve0 = pair.getBalanceForRemoval(token0);
+    uint256 reserve1 = pair.getBalanceForRemoval(token1);
+    uint256 token0Decimals = IBEP20(token0).decimals();
+    uint256 token1Decimals = IBEP20(token1).decimals();
+    uint256 price = (reserve1*10**(token0Decimals-token1Decimals+precisionDecimals))/reserve0;
+    return price;
+  }
+
+  //Gives the price of a given keyToken.
+  function getKeyTokenPrice(address token) internal view returns (uint256) {
+    bool isPricingToken = checkPricingToken(token);
+    uint256 price;
+    uint256 priceVsPricingToken;
+    if (token == definedOutputToken) {
+      price = 10**precisionDecimals;
+    } else if (isPricingToken) {
+      price = getPriceVsTokenPancake(token,definedOutputToken);
+    } else {
+      uint256 pricingTokenPrice;
+      (address pricingToken, bool pancake) = getLargestPool(token,pricingTokens);
+      if (pancake) {
+        priceVsPricingToken = getPriceVsTokenPancake(token,pricingToken);
+      } else {
+        priceVsPricingToken = getPriceVsToken1Inch(token,pricingToken);
+      }
+      pricingTokenPrice = (pricingToken == definedOutputToken)? 10**precisionDecimals:getPriceVsTokenPancake(pricingToken,definedOutputToken);
+      price = priceVsPricingToken*pricingTokenPrice/10**precisionDecimals;
+    }
+    return price;
+  }
+
+  //Checks if a given token is in the pricingTokens list.
+  function checkPricingToken(address token) public view returns (bool) {
+    uint256 i;
+    for (i=0;i<pricingTokens.length;i++) {
+      if (token == pricingTokens[i]) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  //Checks if a given token is in the keyTokens list.
+  function checkKeyToken(address token) public view returns (bool) {
+    uint256 i;
+    for (i=0;i<keyTokens.length;i++) {
+      if (token == keyTokens[i]) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/contracts/interface/mooniswap/IMooniFactory.sol
+++ b/contracts/interface/mooniswap/IMooniFactory.sol
@@ -3,4 +3,5 @@ pragma solidity >=0.5.0;
 interface IMooniFactory {
   function isPool(address token) external view returns(bool);
   function getAllPools() external view returns(address[] memory);
+  function pools(address tokenA, address tokenB) external view returns(address);
 }

--- a/contracts/interface/pancakeswap/IPancakeCallee.sol
+++ b/contracts/interface/pancakeswap/IPancakeCallee.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
+
+interface IPancakeCallee {
+    function pancakeCall(address sender, uint amount0, uint amount1, bytes calldata data) external;
+}

--- a/contracts/interface/pancakeswap/IPancakeERC20.sol
+++ b/contracts/interface/pancakeswap/IPancakeERC20.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
+
+interface IPancakeERC20 {
+    event Approval(address indexed owner, address indexed spender, uint value);
+    event Transfer(address indexed from, address indexed to, uint value);
+
+    function name() external pure returns (string memory);
+    function symbol() external pure returns (string memory);
+    function decimals() external pure returns (uint8);
+    function totalSupply() external view returns (uint);
+    function balanceOf(address owner) external view returns (uint);
+    function allowance(address owner, address spender) external view returns (uint);
+
+    function approve(address spender, uint value) external returns (bool);
+    function transfer(address to, uint value) external returns (bool);
+    function transferFrom(address from, address to, uint value) external returns (bool);
+
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
+    function PERMIT_TYPEHASH() external pure returns (bytes32);
+    function nonces(address owner) external view returns (uint);
+
+    function permit(address owner, address spender, uint value, uint deadline, uint8 v, bytes32 r, bytes32 s) external;
+}

--- a/contracts/interface/pancakeswap/IPancakeFactory.sol
+++ b/contracts/interface/pancakeswap/IPancakeFactory.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
+
+interface IPancakeFactory {
+    event PairCreated(address indexed token0, address indexed token1, address pair, uint);
+
+    function feeTo() external view returns (address);
+    function feeToSetter() external view returns (address);
+
+    function getPair(address tokenA, address tokenB) external view returns (address pair);
+    function allPairs(uint) external view returns (address pair);
+    function allPairsLength() external view returns (uint);
+
+    function createPair(address tokenA, address tokenB) external returns (address pair);
+
+    function setFeeTo(address) external;
+    function setFeeToSetter(address) external;
+}

--- a/contracts/interface/pancakeswap/IPancakePair.sol
+++ b/contracts/interface/pancakeswap/IPancakePair.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
+
+interface IPancakePair {
+    event Approval(address indexed owner, address indexed spender, uint value);
+    event Transfer(address indexed from, address indexed to, uint value);
+
+    event Mint(address indexed sender, uint amount0, uint amount1);
+    event Burn(address indexed sender, uint amount0, uint amount1, address indexed to);
+    event Swap(
+        address indexed sender,
+        uint amount0In,
+        uint amount1In,
+        uint amount0Out,
+        uint amount1Out,
+        address indexed to
+    );
+    event Sync(uint112 reserve0, uint112 reserve1);
+
+    function MINIMUM_LIQUIDITY() external pure returns (uint);
+    function factory() external view returns (address);
+    function token0() external view returns (address);
+    function token1() external view returns (address);
+    function getReserves() external view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast);
+    function price0CumulativeLast() external view returns (uint);
+    function price1CumulativeLast() external view returns (uint);
+    function kLast() external view returns (uint);
+
+    function mint(address to) external returns (uint liquidity);
+    function burn(address to) external returns (uint amount0, uint amount1);
+    function swap(uint amount0Out, uint amount1Out, address to, bytes calldata data) external;
+    function skim(address to) external;
+    function sync() external;
+
+    function initialize(address, address) external;
+}

--- a/contracts/interface/pancakeswap/IPancakeRouter01.sol
+++ b/contracts/interface/pancakeswap/IPancakeRouter01.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
+
+interface IPancakeRouter01 {
+    function factory() external pure returns (address);
+    function WETH() external pure returns (address);
+
+    function addLiquidity(
+        address tokenA,
+        address tokenB,
+        uint amountADesired,
+        uint amountBDesired,
+        uint amountAMin,
+        uint amountBMin,
+        address to,
+        uint deadline
+    ) external returns (uint amountA, uint amountB, uint liquidity);
+    function addLiquidityETH(
+        address token,
+        uint amountTokenDesired,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline
+    ) external payable returns (uint amountToken, uint amountETH, uint liquidity);
+    function removeLiquidity(
+        address tokenA,
+        address tokenB,
+        uint liquidity,
+        uint amountAMin,
+        uint amountBMin,
+        address to,
+        uint deadline
+    ) external returns (uint amountA, uint amountB);
+    function removeLiquidityETH(
+        address token,
+        uint liquidity,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline
+    ) external returns (uint amountToken, uint amountETH);
+    function removeLiquidityWithPermit(
+        address tokenA,
+        address tokenB,
+        uint liquidity,
+        uint amountAMin,
+        uint amountBMin,
+        address to,
+        uint deadline,
+        bool approveMax, uint8 v, bytes32 r, bytes32 s
+    ) external returns (uint amountA, uint amountB);
+    function removeLiquidityETHWithPermit(
+        address token,
+        uint liquidity,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline,
+        bool approveMax, uint8 v, bytes32 r, bytes32 s
+    ) external returns (uint amountToken, uint amountETH);
+    function swapExactTokensForTokens(
+        uint amountIn,
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external returns (uint[] memory amounts);
+    function swapTokensForExactTokens(
+        uint amountOut,
+        uint amountInMax,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external returns (uint[] memory amounts);
+    function swapExactETHForTokens(uint amountOutMin, address[] calldata path, address to, uint deadline)
+        external
+        payable
+        returns (uint[] memory amounts);
+    function swapTokensForExactETH(uint amountOut, uint amountInMax, address[] calldata path, address to, uint deadline)
+        external
+        returns (uint[] memory amounts);
+    function swapExactTokensForETH(uint amountIn, uint amountOutMin, address[] calldata path, address to, uint deadline)
+        external
+        returns (uint[] memory amounts);
+    function swapETHForExactTokens(uint amountOut, address[] calldata path, address to, uint deadline)
+        external
+        payable
+        returns (uint[] memory amounts);
+
+    function quote(uint amountA, uint reserveA, uint reserveB) external pure returns (uint amountB);
+    function getAmountOut(uint amountIn, uint reserveIn, uint reserveOut) external pure returns (uint amountOut);
+    function getAmountIn(uint amountOut, uint reserveIn, uint reserveOut) external pure returns (uint amountIn);
+    function getAmountsOut(uint amountIn, address[] calldata path) external view returns (uint[] memory amounts);
+    function getAmountsIn(uint amountOut, address[] calldata path) external view returns (uint[] memory amounts);
+}

--- a/contracts/interface/pancakeswap/IPancakeRouter02.sol
+++ b/contracts/interface/pancakeswap/IPancakeRouter02.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
+
+import {IPancakeRouter01} from "./IPancakeRouter01.sol";
+
+interface IPancakeRouter02 is IPancakeRouter01 {
+    function removeLiquidityETHSupportingFeeOnTransferTokens(
+        address token,
+        uint liquidity,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline
+    ) external returns (uint amountETH);
+    function removeLiquidityETHWithPermitSupportingFeeOnTransferTokens(
+        address token,
+        uint liquidity,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline,
+        bool approveMax, uint8 v, bytes32 r, bytes32 s
+    ) external returns (uint amountETH);
+
+    function swapExactTokensForTokensSupportingFeeOnTransferTokens(
+        uint amountIn,
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external;
+    function swapExactETHForTokensSupportingFeeOnTransferTokens(
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external payable;
+    function swapExactTokensForETHSupportingFeeOnTransferTokens(
+        uint amountIn,
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external;
+}

--- a/contracts/interface/pancakeswap/IWETH.sol
+++ b/contracts/interface/pancakeswap/IWETH.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
+
+interface IWETH {
+    function deposit() external payable;
+    function transfer(address to, uint value) external returns (bool);
+    function withdraw(uint) external;
+}

--- a/deployment/deployOracleBSC.js
+++ b/deployment/deployOracleBSC.js
@@ -1,0 +1,16 @@
+const Encryption = require('./encryptionTools.js');
+const Deployment = require('./deploymentTools.js');
+const password = Buffer.from(process.env.PASSWORD, 'utf8');
+const storage = process.env.STORAGE_ADDRESS.trim();
+const net = network.name;
+
+async function main() {
+  await Deployment.deploy(password, net, "OracleBSC", storage);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch(error => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/deployment/deployStorageBSC.js
+++ b/deployment/deployStorageBSC.js
@@ -1,0 +1,15 @@
+const Encryption = require('./encryptionTools.js');
+const Deployment = require('./deploymentTools.js');
+const password = Buffer.from(process.env.PASSWORD, 'utf8');
+const net = network.name;
+
+async function main() {
+  await Deployment.deploy(password, net, "Storage");
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch(error => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -4,6 +4,8 @@ require("@nomiclabs/hardhat-truffle5");
 require("hardhat-gas-reporter");
 
 const keys = require('./dev-keys.json');
+const ethForkUrl = "https://eth-mainnet.alchemyapi.io/v2/" + keys.alchemyKeyMainnet;
+const bscForkUrl = "https://bsc-dataseed1.ninicoin.io/";
 
 /**
  * @type import('hardhat/config').HardhatUserConfig
@@ -13,10 +15,10 @@ module.exports = {
   networks: {
     hardhat: {
       allowUnlimitedContractSize: true,
+      chainId: (process.env.FORK_BSC) ? 56 : 1,
       forking: {
-        //url: "https://mainnet.infura.io/v3/" + keys.infuraKey,
-        url: "https://eth-mainnet.alchemyapi.io/v2/" + keys.alchemyKeyMainnet,
-        blockNumber: 11984580
+        url: (process.env.FORK_BSC) ? bscForkUrl : ethForkUrl,
+        blockNumber: (process.env.FORK_BSC) ? undefined : 11984580,
       }
     },
     ropsten: {
@@ -26,7 +28,11 @@ module.exports = {
     },
     mainnet: {
       url: "https://eth-mainnet.alchemyapi.io/v2/" + keys.alchemyKeyMainnet,
-    }
+    },
+    bsc: {
+      url: "https://bsc-dataseed.binance.org/",
+      chainId: 56,
+    },
   },
   etherscan: {
     apiKey: keys.etherscanAPI

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@nomiclabs/hardhat-web3": "^2.0.0",
     "@openzeppelin/contracts": "^3.4.0",
     "@openzeppelin/contracts-ethereum-package": "^3.0.0",
+    "@pancakeswap/pancake-swap-lib": "^0.0.4",
     "coingecko-api": "^1.0.10",
     "sodium": "^3.0.2"
   },

--- a/test/bsc-fork-test-OracleBSC.js
+++ b/test/bsc-fork-test-OracleBSC.js
@@ -1,0 +1,180 @@
+// Utilities
+const Utils = require("./utilities/Utils.js");
+const MFC = require("./mainnet-fork-test-config.js");
+
+const { send } = require("@openzeppelin/test-helpers");
+const BigNumber = require("bignumber.js");
+const IPancakeFactory = artifacts.require("IPancakeFactory");
+const IPancakePair = artifacts.require("IPancakePair");
+const IMooniFactory = artifacts.require("IMooniFactory")
+
+//const Strategy = artifacts.require("");
+const Storage = artifacts.require("Storage");
+const OracleBSC = artifacts.require("OracleBSC");
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Testing all functionality", function (){
+
+  function sum(total,num) {
+    return BigNumber.sum(total,num);
+  }
+  let accounts;
+  let precisionDecimals = 18;
+  // parties in the protocol
+
+  // Core protocol contracts
+  let storage;
+  let oracle;
+
+  let pancakeFactoryAddress = "0xBCfCcbde45cE874adCB698cC183deBcF17952812";
+  let oneInchFactoryAddress = "0xD41B24bbA51fAc0E4827b6F94C0D6DDeB183cD64";
+
+  let normalTokens = ["0x4b5c23cac08a567ecf0c1ffca8372a45a5d33743", "0xf952fc3ca7325cc27d15885d37117676d25bfda6", "0x0e09fabb73bd3ade0a17ecc321fd13a19e81ce82", "0xcf6bb5389c92bdda8a3747ddb454cb7a64626c63",
+                  "0x0d9319565be7f53cefe84ad201be3f40feae2740", "0xfce146bf3146100cfe5db4129cf6c82b0ef4ad8c", "0x111111111117dc0aa78b770fa6a738034120c302"];
+  let pancakeLPs = ["0xA527a61703D82139F8a06Bc30097cC9CAA2df5A6","0x1B96B92314C44b159149f7E0303511fB2Fc4774f","0x7561EEe90e24F3b348E1087A005F78B4c8453524","0x70D8929d04b60Af4fb9B58713eBcf18765aDE422",
+                "0xc15fa3E22c912A276550F3E5FE3b0Deb87B55aCd","0x99d865Ed50D2C32c1493896810FA386c1Ce81D91","0x20bCC3b8a0091dDac2d0BC30F68E6CBb97de59Cd","0xfF17ff314925Dff772b71AbdFF2782bC913B3575",
+                "0x7Bb89460599Dbf32ee3Aa50798BBcEae2A5F7f6a","0xbCD62661A6b1DEd703585d3aF7d7649Ef4dcDB5c"];
+  let oneInchLPs = ["0xdaF66c0B7e8E2FC76B15B07AD25eE58E04a66796","0xc33876129A6AC1022d316Ac824f8eab58C7d303B", "0xe3f6509818ccf031370bB4cb398EB37C21622ac4"];
+
+  let keyTokens = [
+    "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d", //USDC
+    "0x2170Ed0880ac9A755fd29B2688956BD959F933F8", //ETH
+    "0x1AF3F329e8BE154074D8769D1FFa4eE058B1DBc3", //DAI
+    "0x55d398326f99059fF775485246999027B3197955", //USDT
+    "0x23396cF899Ca06c4472205fC903bDB4de249D6fC", //UST
+    "0x7130d2A12B9BCbFAe4f2634d864A1Ee1Ce3Ead9c", //BTCB
+    "0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56", //BUSD
+    "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c", //WBNB
+    "0x4BD17003473389A42DAF6a0a729f6Fdb328BbBd7" //VAI
+  ];
+  let pricingTokens = [
+    "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c", //WBNB
+    "0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56", //BUSD
+    "0x55d398326f99059fF775485246999027B3197955", //USDT
+    "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d", //USDC
+    "0x4BD17003473389A42DAF6a0a729f6Fdb328BbBd7", //VAI
+    "0x1AF3F329e8BE154074D8769D1FFa4eE058B1DBc3" //DAI
+  ];
+  let definedOutputToken = "0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56"; //BUSD
+
+  before(async function () {
+    console.log("Setting up contract")
+    accounts = await web3.eth.getAccounts();
+    governance = accounts[1];
+    // deploy storage
+    storage = await Storage.new({ from: governance });
+    //deploy Oracle
+    oracle = await OracleBSC.new(storage.address, {from: governance});
+
+    pancakeswapFactory = await IPancakeFactory.at(pancakeFactoryAddress);
+    oneInchFactory = await IMooniFactory.at(oneInchFactoryAddress);
+  });
+
+  it("Normal Tokens", async function () {
+    checkTokens = [
+      "0xfce146bf3146100cfe5db4129cf6c82b0ef4ad8c"
+    ]
+
+    for (i=0;i<checkTokens.length;i++) {
+      console.log("Check Token",i,checkTokens[i]);
+      try {
+        console.time("getPrice");
+        price = await oracle.getPrice(checkTokens[i]);
+        console.timeEnd("getPrice");
+        console.log("price:", BigNumber(price).toFixed()/10**precisionDecimals);
+      } catch (error) {
+        price = 0;
+        console.log("Error at Token", i, checkTokens[i]);
+      }
+      console.log("");
+    }
+
+    for (i=0;i<keyTokens.length;i++) {
+      console.log("Key Token",i,keyTokens[i]);
+      try {
+        console.time("getPrice");
+        price = await oracle.getPrice(keyTokens[i]);
+        console.timeEnd("getPrice");
+        console.log("price:", BigNumber(price).toFixed()/10**precisionDecimals);
+      } catch (error) {
+        price = 0;
+        console.log("Error at Token", i, keyTokens[i]);
+      }
+      console.log("");
+    }
+
+    for (i=0;i<normalTokens.length;i++) {
+      console.log("Token",i,normalTokens[i]);
+      try {
+        console.time("getPrice");
+        price = await oracle.getPrice(normalTokens[i]);
+        console.timeEnd("getPrice");
+        console.log("price:", BigNumber(price).toFixed()/10**precisionDecimals);
+      } catch (error) {
+        price = 0;
+        console.log("Error at Token", i, normalTokens[i]);
+      }
+      console.log("");
+    }
+  });
+
+  it("Pancake LPs Repeatable", async function() {
+    for (i=0;i<pancakeLPs.length;i++) {
+      console.log("Pancake token",i,pancakeLPs[i]);
+      try {
+        console.time("getPrice");
+        price = await oracle.getPrice(pancakeLPs[i]);
+        console.timeEnd("getPrice");
+        console.log("price:", BigNumber(price).toFixed()/10**precisionDecimals);
+      } catch {
+        console.log("Error at Pancake", i, pancakeLPs[i]);
+      }
+      console.log("")
+    }
+  });
+
+  it("1Inch LPs Repeatable", async function() {
+    for (i=0;i<oneInchLPs.length;i++) {
+      console.log("OneInch token",i,oneInchLPs[i]);
+      try {
+        console.time("getPrice");
+        price = await oracle.getPrice(oneInchLPs[i]);
+        console.timeEnd("getPrice");
+        console.log("price:", BigNumber(price).toFixed()/10**precisionDecimals);
+      } catch {
+        console.log("Error at 1INCH", i, oneInchLPs[i]);
+      }
+      console.log("")
+    }
+  });
+
+  it("Control functions", async function() {
+    console.log("Change factories");
+    await oracle.changePancakeFactory(oneInchFactoryAddress, {from: governance});
+    await oracle.changeOneInchFactory(pancakeFactoryAddress, {from: governance});
+    console.log("Change back");
+    await oracle.changePancakeFactory(pancakeFactoryAddress, {from: governance});
+    await oracle.changeOneInchFactory(oneInchFactoryAddress, {from: governance});
+    console.log("Add FARM as key token");
+    await oracle.addKeyToken(MFC.FARM_ADDRESS, {from: governance});
+    isKeyToken = await oracle.checkKeyToken(MFC.FARM_ADDRESS, {from: governance});
+    console.log("FARM is key token:",isKeyToken);
+    console.log("Add FARM as pricing token");
+    await oracle.addPricingToken(MFC.FARM_ADDRESS, {from: governance});
+    isPricingToken = await oracle.checkPricingToken(MFC.FARM_ADDRESS, {from: governance});
+    console.log("FARM is pricing token:", isPricingToken);
+    console.log("Remove FARM as key token");
+    await oracle.removeKeyToken(MFC.FARM_ADDRESS, {from: governance});
+    isKeyToken = await oracle.checkKeyToken(MFC.FARM_ADDRESS, {from: governance});
+    console.log("FARM is key token:",isKeyToken);
+    isPricingToken = await oracle.checkPricingToken(MFC.FARM_ADDRESS, {from: governance});
+    console.log("FARM is pricing token:", isPricingToken);
+    console.log("Change defined output to WBNB");
+    await oracle.changeDefinedOutput("0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c", {from: governance});
+    bnbPrice = await oracle.getPrice("0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c", {from: governance});
+    console.log("WBNB price:", BigNumber(bnbPrice).toFixed()/10**precisionDecimals);
+    busdPrice = await oracle.getPrice("0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56", {from: governance});
+    console.log("BUSD price:", BigNumber(busdPrice).toFixed()/10**precisionDecimals);
+  });
+
+});


### PR DESCRIPTION
Oracle for BSC currently supporting any single token with liquidity on Pancake and 1INCH and any Pancake and 1INCH LP token.