### PR TITLE
tested with 5 curve pools (ellipsis, belt, nerve ,acs, dopple)- OK

### DIFF
--- a/contracts/StableSwapOracle.sol
+++ b/contracts/StableSwapOracle.sol
@@ -2,7 +2,6 @@
 
 pragma solidity ^0.6.12;
 
-//import "@openzeppelin/contracts/utils/Address.sol";
 import "@openzeppelin/contracts/utils/SafeCast.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
@@ -15,17 +14,19 @@ contract StableSwapOracle is Ownable {
     using SafeCast for int;
 
     struct StableSwapProvider {
-        string name;
         address addr;
         bytes4 coins; // representing the function that gives underlying coins f(uint256) -> address
         bytes4 exchange; // representing function that gives the output amount f(int128,int128,uint256) -> uint256
     }
 
-    mapping(string => StableSwapProvider) public registry;
+    mapping(address => StableSwapProvider) public registry;
 
-    string[] stableSwapProviders;
+    address public defaultProvider = 0x160CAed03795365F3A589f10C379FfA7d75d4E76;
+    address public defaultSecondToken = 0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56;
 
-    function _getCoinIndex(address _target, address _token, bytes memory data) private view
+    address[] private stableSwapProviders;
+
+    function _getCoinIndex(address _target, bytes memory data) private view
     returns (bool, address)
     {
 
@@ -45,49 +46,71 @@ contract StableSwapOracle is Ownable {
         bytes memory data;
         address returnAddress;
         bool success;
+        bool gotKey0 = false;
+        bool gotKey1 = false;
         uint256 key0;
         uint256 key1;
 
         for (uint256 i = 0; i < 10; i++) {
 
             data = abi.encodeWithSelector(_coins, i);
-            (success, returnAddress) = _getCoinIndex(_target, _token0, data);
+            (success, returnAddress) = _getCoinIndex(_target, data);
 
             if (returnAddress == _token0 && success) {
                 key0 = i;
-
+                gotKey0 = true;
             } else if (returnAddress == _token1 && success) {
                 key1 = i;
-
+                gotKey1 = true;
             } else if (!success) {
                 break;
             }
         }
 
-        return (true, key0, key1);
+        return (gotKey0 && gotKey1, key0, key1);
     }
 
-    function addStableSwapProvider(string memory _name, address _addr, bytes4 _coins, bytes4 _exchange)
+    function addStableSwapProvider(address _addr, bytes4 _coins, bytes4 _exchange)
     public
     onlyOwner
     returns (bool)
     {
         StableSwapProvider memory s;
 
-        s.name = _name;
         s.addr = _addr;
         s.coins = _coins;
         s.exchange = _exchange;
 
-        registry[_name] = s;
+        registry[_addr] = s;
 
+        stableSwapProviders.push(_addr);
         return true;
     }
 
-    function getRate(string memory _name, address _token0, address _token1) public view
+    function changeDefaultProvider(address _addr) public onlyOwner
+    returns (bool)
+    {
+        require(_addr != address(0));
+        defaultProvider = _addr;
+        return true;
+
+    }
+
+    function changeDefaultSecondToken(address _addr) public onlyOwner
+    returns (bool)
+    {
+        require(_addr != address(0));
+        defaultSecondToken = _addr;
+        return true;
+
+    }
+
+    function _getPriceStables(address _addr, address _token0, address _token1) private view
     returns (bool, uint256)
     {
-        StableSwapProvider memory s = registry[_name];
+        require(_token0 != _token1, "cannot get rate for identical tokens");
+
+        StableSwapProvider memory s = registry[_addr];
         IERC20 token0 = IERC20(_token0);
         uint256 decimals = token0.decimals();
         uint256 token_amount = 10 ** decimals;
@@ -96,8 +119,8 @@ contract StableSwapOracle is Ownable {
 
         require(keysSuccess, "couldn't find tokens in this exchange");
 
-        int128 key0 = _key0.toInt256().toInt128();
-        int128 key1 = _key1.toInt256().toInt128();
+        uint8 key0 = _key0.toUint8();
+        uint8 key1 = _key1.toUint8();
 
         bytes memory data = abi.encodeWithSelector(s.exchange, key0, key1, token_amount);
 
@@ -106,6 +129,69 @@ contract StableSwapOracle is Ownable {
         require(success, "failed to get exchange rate");
 
         return (true, abi.decode(returnData, (uint256)));
+    }
+
+    function getPriceStables(address _addr, address _token0, address _token1) public view
+    returns (bool, uint256)
+    {
+        return _getPriceStables(_addr, _token0, _token1);
+    }
+
+    // will use default second token
+    function getPriceStables(address _addr, address _token0) public view
+    returns (bool, uint256)
+    {
+        return _getPriceStables(_addr, _token0, defaultSecondToken);
+    }
+
+    // will use the default provider and as second token default second token
+    function getPriceStables(address _token0) public view
+    returns (bool, uint256)
+    {
+        return _getPriceStables(defaultProvider, _token0, defaultSecondToken);
+    }
+
+    function getCoins(address _addr) public view
+    returns (address[] memory)
+    {
+        StableSwapProvider memory s = registry[_addr];
+        bytes memory data;
+        address returnAddress;
+        bool success;
+        uint8 counter = 0;
+        address[] memory addys = new address[](10);
+
+        for (uint256 i = 0; i < 10; i++) {
+
+            data = abi.encodeWithSelector(s.coins, i);
+            (success, returnAddress) = _getCoinIndex(_addr, data);
+
+            if (success) {
+                addys[i] = returnAddress;
+                counter = counter + 1;
+            } else if (!success) {
+                break;
+            }
+        }
+
+        address[] memory _addys = new address[](counter);
+        for (uint256 i = 0; i < _addys.length; i++) {
+            _addys[i] = addys[i];
+        }
+
+        return _addys;
+    }
+
+    function getStableSwapProviders() public view
+    returns (address[] memory)
+    {
+        address[] memory addys = new address[](stableSwapProviders.length);
+
+        for (uint256 i = 0; i < stableSwapProviders.length; i++) {
+            addys[i] = stableSwapProviders[i];
+        }
+
+        return addys;
     }
 
 }

--- a/interfaces/BEP20.json
+++ b/interfaces/BEP20.json
@@ -1,0 +1,418 @@
+[
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "burn",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "subtractedValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "decreaseAllowance",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getOwner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "addedValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "increaseAllowance",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "symbol",
+        "type": "string"
+      },
+      {
+        "internalType": "uint8",
+        "name": "decimals",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "mintable",
+        "type": "bool"
+      },
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "mint",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "mintable",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/interfaces/belt.json
+++ b/interfaces/belt.json
@@ -1,0 +1,878 @@
+[
+  {
+    "name": "TokenExchange",
+    "inputs": [
+      {
+        "type": "address",
+        "name": "buyer",
+        "indexed": true
+      },
+      {
+        "type": "int128",
+        "name": "sold_id",
+        "indexed": false
+      },
+      {
+        "type": "uint256",
+        "name": "tokens_sold",
+        "indexed": false
+      },
+      {
+        "type": "int128",
+        "name": "bought_id",
+        "indexed": false
+      },
+      {
+        "type": "uint256",
+        "name": "tokens_bought",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "TokenExchangeUnderlying",
+    "inputs": [
+      {
+        "type": "address",
+        "name": "buyer",
+        "indexed": true
+      },
+      {
+        "type": "int128",
+        "name": "sold_id",
+        "indexed": false
+      },
+      {
+        "type": "uint256",
+        "name": "tokens_sold",
+        "indexed": false
+      },
+      {
+        "type": "int128",
+        "name": "bought_id",
+        "indexed": false
+      },
+      {
+        "type": "uint256",
+        "name": "tokens_bought",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "AddLiquidity",
+    "inputs": [
+      {
+        "type": "address",
+        "name": "provider",
+        "indexed": true
+      },
+      {
+        "type": "uint256[4]",
+        "name": "token_amounts",
+        "indexed": false
+      },
+      {
+        "type": "uint256[4]",
+        "name": "fees",
+        "indexed": false
+      },
+      {
+        "type": "uint256",
+        "name": "invariant",
+        "indexed": false
+      },
+      {
+        "type": "uint256",
+        "name": "token_supply",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "RemoveLiquidity",
+    "inputs": [
+      {
+        "type": "address",
+        "name": "provider",
+        "indexed": true
+      },
+      {
+        "type": "uint256[4]",
+        "name": "token_amounts",
+        "indexed": false
+      },
+      {
+        "type": "uint256[4]",
+        "name": "fees",
+        "indexed": false
+      },
+      {
+        "type": "uint256",
+        "name": "token_supply",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "RemoveLiquidityImbalance",
+    "inputs": [
+      {
+        "type": "address",
+        "name": "provider",
+        "indexed": true
+      },
+      {
+        "type": "uint256[4]",
+        "name": "token_amounts",
+        "indexed": false
+      },
+      {
+        "type": "uint256[4]",
+        "name": "fees",
+        "indexed": false
+      },
+      {
+        "type": "uint256",
+        "name": "invariant",
+        "indexed": false
+      },
+      {
+        "type": "uint256",
+        "name": "token_supply",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "CommitNewAdmin",
+    "inputs": [
+      {
+        "type": "uint256",
+        "name": "deadline",
+        "indexed": true,
+        "unit": "sec"
+      },
+      {
+        "type": "address",
+        "name": "admin",
+        "indexed": true
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "NewAdmin",
+    "inputs": [
+      {
+        "type": "address",
+        "name": "admin",
+        "indexed": true
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "CommitNewParameters",
+    "inputs": [
+      {
+        "type": "uint256",
+        "name": "deadline",
+        "indexed": true,
+        "unit": "sec"
+      },
+      {
+        "type": "uint256",
+        "name": "A",
+        "indexed": false
+      },
+      {
+        "type": "uint256",
+        "name": "fee",
+        "indexed": false
+      },
+      {
+        "type": "uint256",
+        "name": "buyback_fee",
+        "indexed": false
+      },
+      {
+        "type": "address",
+        "name": "buyback_addr",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "NewParameters",
+    "inputs": [
+      {
+        "type": "uint256",
+        "name": "A",
+        "indexed": false
+      },
+      {
+        "type": "uint256",
+        "name": "fee",
+        "indexed": false
+      },
+      {
+        "type": "uint256",
+        "name": "buyback_fee",
+        "indexed": false
+      },
+      {
+        "type": "address",
+        "name": "buyback_addr",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "outputs": [],
+    "inputs": [
+      {
+        "type": "address[4]",
+        "name": "_coins"
+      },
+      {
+        "type": "address[4]",
+        "name": "_underlying_coins"
+      },
+      {
+        "type": "address",
+        "name": "_pool_token"
+      },
+      {
+        "type": "uint256",
+        "name": "_A"
+      },
+      {
+        "type": "uint256",
+        "name": "_fee"
+      },
+      {
+        "type": "uint256",
+        "name": "_buyback_fee"
+      },
+      {
+        "type": "address",
+        "name": "_buyback_addr"
+      }
+    ],
+    "constant": false,
+    "payable": false,
+    "type": "constructor"
+  },
+  {
+    "name": "pool_token",
+    "outputs": [
+      {
+        "type": "address",
+        "name": "out"
+      }
+    ],
+    "inputs": [],
+    "constant": true,
+    "payable": false,
+    "type": "function",
+    "gas": 1151
+  },
+  {
+    "name": "get_virtual_price",
+    "outputs": [
+      {
+        "type": "uint256",
+        "name": "out"
+      }
+    ],
+    "inputs": [],
+    "constant": true,
+    "payable": false,
+    "type": "function",
+    "gas": 1535305
+  },
+  {
+    "name": "calc_token_amount",
+    "outputs": [
+      {
+        "type": "uint256",
+        "name": "out"
+      }
+    ],
+    "inputs": [
+      {
+        "type": "uint256[4]",
+        "name": "amounts"
+      },
+      {
+        "type": "bool",
+        "name": "deposit"
+      }
+    ],
+    "constant": true,
+    "payable": false,
+    "type": "function",
+    "gas": 6068241
+  },
+  {
+    "name": "add_liquidity",
+    "outputs": [],
+    "inputs": [
+      {
+        "type": "uint256[4]",
+        "name": "amounts"
+      },
+      {
+        "type": "uint256",
+        "name": "min_mint_amount"
+      }
+    ],
+    "constant": false,
+    "payable": false,
+    "type": "function",
+    "gas": 9327593
+  },
+  {
+    "name": "get_dy",
+    "outputs": [
+      {
+        "type": "uint256",
+        "name": "out"
+      }
+    ],
+    "inputs": [
+      {
+        "type": "int128",
+        "name": "i"
+      },
+      {
+        "type": "int128",
+        "name": "j"
+      },
+      {
+        "type": "uint256",
+        "name": "dx"
+      }
+    ],
+    "constant": true,
+    "payable": false,
+    "type": "function",
+    "gas": 3454407
+  },
+  {
+    "name": "get_dx",
+    "outputs": [
+      {
+        "type": "uint256",
+        "name": "out"
+      }
+    ],
+    "inputs": [
+      {
+        "type": "int128",
+        "name": "i"
+      },
+      {
+        "type": "int128",
+        "name": "j"
+      },
+      {
+        "type": "uint256",
+        "name": "dy"
+      }
+    ],
+    "constant": true,
+    "payable": false,
+    "type": "function",
+    "gas": 3454412
+  },
+  {
+    "name": "get_dy_underlying",
+    "outputs": [
+      {
+        "type": "uint256",
+        "name": "out"
+      }
+    ],
+    "inputs": [
+      {
+        "type": "int128",
+        "name": "i"
+      },
+      {
+        "type": "int128",
+        "name": "j"
+      },
+      {
+        "type": "uint256",
+        "name": "dx"
+      }
+    ],
+    "constant": true,
+    "payable": false,
+    "type": "function",
+    "gas": 3454267
+  },
+  {
+    "name": "get_dx_underlying",
+    "outputs": [
+      {
+        "type": "uint256",
+        "name": "out"
+      }
+    ],
+    "inputs": [
+      {
+        "type": "int128",
+        "name": "i"
+      },
+      {
+        "type": "int128",
+        "name": "j"
+      },
+      {
+        "type": "uint256",
+        "name": "dy"
+      }
+    ],
+    "constant": true,
+    "payable": false,
+    "type": "function",
+    "gas": 3454273
+  },
+  {
+    "name": "exchange",
+    "outputs": [],
+    "inputs": [
+      {
+        "type": "int128",
+        "name": "i"
+      },
+      {
+        "type": "int128",
+        "name": "j"
+      },
+      {
+        "type": "uint256",
+        "name": "dx"
+      },
+      {
+        "type": "uint256",
+        "name": "min_dy"
+      }
+    ],
+    "constant": false,
+    "payable": false,
+    "type": "function",
+    "gas": 7030538
+  },
+  {
+    "name": "exchange_underlying",
+    "outputs": [],
+    "inputs": [
+      {
+        "type": "int128",
+        "name": "i"
+      },
+      {
+        "type": "int128",
+        "name": "j"
+      },
+      {
+        "type": "uint256",
+        "name": "dx"
+      },
+      {
+        "type": "uint256",
+        "name": "min_dy"
+      }
+    ],
+    "constant": false,
+    "payable": false,
+    "type": "function",
+    "gas": 7057905
+  },
+  {
+    "name": "remove_liquidity",
+    "outputs": [],
+    "inputs": [
+      {
+        "type": "uint256",
+        "name": "_amount"
+      },
+      {
+        "type": "uint256[4]",
+        "name": "min_amounts"
+      }
+    ],
+    "constant": false,
+    "payable": false,
+    "type": "function",
+    "gas": 240439
+  },
+  {
+    "name": "remove_liquidity_imbalance",
+    "outputs": [],
+    "inputs": [
+      {
+        "type": "uint256[4]",
+        "name": "amounts"
+      },
+      {
+        "type": "uint256",
+        "name": "max_burn_amount"
+      }
+    ],
+    "constant": false,
+    "payable": false,
+    "type": "function",
+    "gas": 9326820
+  },
+  {
+    "name": "commit_new_parameters",
+    "outputs": [],
+    "inputs": [
+      {
+        "type": "uint256",
+        "name": "amplification"
+      },
+      {
+        "type": "uint256",
+        "name": "new_fee"
+      },
+      {
+        "type": "uint256",
+        "name": "new_buyback_fee"
+      },
+      {
+        "type": "address",
+        "name": "new_buyback_addr"
+      }
+    ],
+    "constant": false,
+    "payable": false,
+    "type": "function",
+    "gas": 181536
+  },
+  {
+    "name": "apply_new_parameters",
+    "outputs": [],
+    "inputs": [],
+    "constant": false,
+    "payable": false,
+    "type": "function",
+    "gas": 169924
+  },
+  {
+    "name": "revert_new_parameters",
+    "outputs": [],
+    "inputs": [],
+    "constant": false,
+    "payable": false,
+    "type": "function",
+    "gas": 21835
+  },
+  {
+    "name": "commit_transfer_ownership",
+    "outputs": [],
+    "inputs": [
+      {
+        "type": "address",
+        "name": "_owner"
+      }
+    ],
+    "constant": false,
+    "payable": false,
+    "type": "function",
+    "gas": 74512
+  },
+  {
+    "name": "apply_transfer_ownership",
+    "outputs": [],
+    "inputs": [],
+    "constant": false,
+    "payable": false,
+    "type": "function",
+    "gas": 60568
+  },
+  {
+    "name": "revert_transfer_ownership",
+    "outputs": [],
+    "inputs": [],
+    "constant": false,
+    "payable": false,
+    "type": "function",
+    "gas": 21925
+  },
+  {
+    "name": "withdraw_buyback_fees",
+    "outputs": [],
+    "inputs": [],
+    "constant": false,
+    "payable": false,
+    "type": "function",
+    "gas": 25008
+  },
+  {
+    "name": "kill_me",
+    "outputs": [],
+    "inputs": [],
+    "constant": false,
+    "payable": false,
+    "type": "function",
+    "gas": 37878
+  },
+  {
+    "name": "unkill_me",
+    "outputs": [],
+    "inputs": [],
+    "constant": false,
+    "payable": false,
+    "type": "function",
+    "gas": 22015
+  },
+  {
+    "name": "coins",
+    "outputs": [
+      {
+        "type": "address",
+        "name": "out"
+      }
+    ],
+    "inputs": [
+      {
+        "type": "int128",
+        "name": "arg0"
+      }
+    ],
+    "constant": true,
+    "payable": false,
+    "type": "function",
+    "gas": 2190
+  },
+  {
+    "name": "underlying_coins",
+    "outputs": [
+      {
+        "type": "address",
+        "name": "out"
+      }
+    ],
+    "inputs": [
+      {
+        "type": "int128",
+        "name": "arg0"
+      }
+    ],
+    "constant": true,
+    "payable": false,
+    "type": "function",
+    "gas": 2220
+  },
+  {
+    "name": "balances",
+    "outputs": [
+      {
+        "type": "uint256",
+        "name": "out"
+      }
+    ],
+    "inputs": [
+      {
+        "type": "int128",
+        "name": "arg0"
+      }
+    ],
+    "constant": true,
+    "payable": false,
+    "type": "function",
+    "gas": 2250
+  },
+  {
+    "name": "A",
+    "outputs": [
+      {
+        "type": "uint256",
+        "name": "out"
+      }
+    ],
+    "inputs": [],
+    "constant": true,
+    "payable": false,
+    "type": "function",
+    "gas": 2081
+  },
+  {
+    "name": "fee",
+    "outputs": [
+      {
+        "type": "uint256",
+        "name": "out"
+      }
+    ],
+    "inputs": [],
+    "constant": true,
+    "payable": false,
+    "type": "function",
+    "gas": 2111
+  },
+  {
+    "name": "buyback_fee",
+    "outputs": [
+      {
+        "type": "uint256",
+        "name": "out"
+      }
+    ],
+    "inputs": [],
+    "constant": true,
+    "payable": false,
+    "type": "function",
+    "gas": 2141
+  },
+  {
+    "name": "owner",
+    "outputs": [
+      {
+        "type": "address",
+        "name": "out"
+      }
+    ],
+    "inputs": [],
+    "constant": true,
+    "payable": false,
+    "type": "function",
+    "gas": 2171
+  },
+  {
+    "name": "buyback_addr",
+    "outputs": [
+      {
+        "type": "address",
+        "name": "out"
+      }
+    ],
+    "inputs": [],
+    "constant": true,
+    "payable": false,
+    "type": "function",
+    "gas": 2201
+  },
+  {
+    "name": "admin_actions_deadline",
+    "outputs": [
+      {
+        "type": "uint256",
+        "unit": "sec",
+        "name": "out"
+      }
+    ],
+    "inputs": [],
+    "constant": true,
+    "payable": false,
+    "type": "function",
+    "gas": 2231
+  },
+  {
+    "name": "transfer_ownership_deadline",
+    "outputs": [
+      {
+        "type": "uint256",
+        "unit": "sec",
+        "name": "out"
+      }
+    ],
+    "inputs": [],
+    "constant": true,
+    "payable": false,
+    "type": "function",
+    "gas": 2261
+  },
+  {
+    "name": "future_A",
+    "outputs": [
+      {
+        "type": "uint256",
+        "name": "out"
+      }
+    ],
+    "inputs": [],
+    "constant": true,
+    "payable": false,
+    "type": "function",
+    "gas": 2291
+  },
+  {
+    "name": "future_fee",
+    "outputs": [
+      {
+        "type": "uint256",
+        "name": "out"
+      }
+    ],
+    "inputs": [],
+    "constant": true,
+    "payable": false,
+    "type": "function",
+    "gas": 2321
+  },
+  {
+    "name": "future_buyback_fee",
+    "outputs": [
+      {
+        "type": "uint256",
+        "name": "out"
+      }
+    ],
+    "inputs": [],
+    "constant": true,
+    "payable": false,
+    "type": "function",
+    "gas": 2351
+  },
+  {
+    "name": "future_owner",
+    "outputs": [
+      {
+        "type": "address",
+        "name": "out"
+      }
+    ],
+    "inputs": [],
+    "constant": true,
+    "payable": false,
+    "type": "function",
+    "gas": 2381
+  },
+  {
+    "name": "future_buyback_addr",
+    "outputs": [
+      {
+        "type": "address",
+        "name": "out"
+      }
+    ],
+    "inputs": [],
+    "constant": true,
+    "payable": false,
+    "type": "function",
+    "gas": 2411
+  }
+]

--- a/interfaces/e3p.json
+++ b/interfaces/e3p.json
@@ -1,0 +1,847 @@
+[
+  {
+    "name": "TokenExchange",
+    "inputs": [
+      {
+        "name": "buyer",
+        "type": "address",
+        "indexed": true
+      },
+      {
+        "name": "sold_id",
+        "type": "int128",
+        "indexed": false
+      },
+      {
+        "name": "tokens_sold",
+        "type": "uint256",
+        "indexed": false
+      },
+      {
+        "name": "bought_id",
+        "type": "int128",
+        "indexed": false
+      },
+      {
+        "name": "tokens_bought",
+        "type": "uint256",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "AddLiquidity",
+    "inputs": [
+      {
+        "name": "provider",
+        "type": "address",
+        "indexed": true
+      },
+      {
+        "name": "token_amounts",
+        "type": "uint256[3]",
+        "indexed": false
+      },
+      {
+        "name": "fees",
+        "type": "uint256[3]",
+        "indexed": false
+      },
+      {
+        "name": "invariant",
+        "type": "uint256",
+        "indexed": false
+      },
+      {
+        "name": "token_supply",
+        "type": "uint256",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "RemoveLiquidity",
+    "inputs": [
+      {
+        "name": "provider",
+        "type": "address",
+        "indexed": true
+      },
+      {
+        "name": "token_amounts",
+        "type": "uint256[3]",
+        "indexed": false
+      },
+      {
+        "name": "fees",
+        "type": "uint256[3]",
+        "indexed": false
+      },
+      {
+        "name": "token_supply",
+        "type": "uint256",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "RemoveLiquidityOne",
+    "inputs": [
+      {
+        "name": "provider",
+        "type": "address",
+        "indexed": true
+      },
+      {
+        "name": "token_amount",
+        "type": "uint256",
+        "indexed": false
+      },
+      {
+        "name": "coin_amount",
+        "type": "uint256",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "RemoveLiquidityImbalance",
+    "inputs": [
+      {
+        "name": "provider",
+        "type": "address",
+        "indexed": true
+      },
+      {
+        "name": "token_amounts",
+        "type": "uint256[3]",
+        "indexed": false
+      },
+      {
+        "name": "fees",
+        "type": "uint256[3]",
+        "indexed": false
+      },
+      {
+        "name": "invariant",
+        "type": "uint256",
+        "indexed": false
+      },
+      {
+        "name": "token_supply",
+        "type": "uint256",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "CommitNewAdmin",
+    "inputs": [
+      {
+        "name": "deadline",
+        "type": "uint256",
+        "indexed": true
+      },
+      {
+        "name": "admin",
+        "type": "address",
+        "indexed": true
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "NewAdmin",
+    "inputs": [
+      {
+        "name": "admin",
+        "type": "address",
+        "indexed": true
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "CommitNewFee",
+    "inputs": [
+      {
+        "name": "deadline",
+        "type": "uint256",
+        "indexed": true
+      },
+      {
+        "name": "fee",
+        "type": "uint256",
+        "indexed": false
+      },
+      {
+        "name": "admin_fee",
+        "type": "uint256",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "NewFee",
+    "inputs": [
+      {
+        "name": "fee",
+        "type": "uint256",
+        "indexed": false
+      },
+      {
+        "name": "admin_fee",
+        "type": "uint256",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "RampA",
+    "inputs": [
+      {
+        "name": "old_A",
+        "type": "uint256",
+        "indexed": false
+      },
+      {
+        "name": "new_A",
+        "type": "uint256",
+        "indexed": false
+      },
+      {
+        "name": "initial_time",
+        "type": "uint256",
+        "indexed": false
+      },
+      {
+        "name": "future_time",
+        "type": "uint256",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "StopRampA",
+    "inputs": [
+      {
+        "name": "A",
+        "type": "uint256",
+        "indexed": false
+      },
+      {
+        "name": "t",
+        "type": "uint256",
+        "indexed": false
+      }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "name": "_coins",
+        "type": "address[3]"
+      },
+      {
+        "name": "_pool_token",
+        "type": "address"
+      },
+      {
+        "name": "_A",
+        "type": "uint256"
+      },
+      {
+        "name": "_fee",
+        "type": "uint256"
+      },
+      {
+        "name": "_admin_fee",
+        "type": "uint256"
+      },
+      {
+        "name": "_fee_converter",
+        "type": "address"
+      }
+    ],
+    "outputs": []
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "A",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "gas": 5106
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "get_virtual_price",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "gas": 1132771
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "calc_token_amount",
+    "inputs": [
+      {
+        "name": "amounts",
+        "type": "uint256[3]"
+      },
+      {
+        "name": "deposit",
+        "type": "bool"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "gas": 4506209
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "add_liquidity",
+    "inputs": [
+      {
+        "name": "amounts",
+        "type": "uint256[3]"
+      },
+      {
+        "name": "min_mint_amount",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [],
+    "gas": 6950840
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "get_dy",
+    "inputs": [
+      {
+        "name": "i",
+        "type": "int128"
+      },
+      {
+        "name": "j",
+        "type": "int128"
+      },
+      {
+        "name": "dx",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "gas": 2672568
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "get_dy_underlying",
+    "inputs": [
+      {
+        "name": "i",
+        "type": "int128"
+      },
+      {
+        "name": "j",
+        "type": "int128"
+      },
+      {
+        "name": "dx",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "gas": 2672270
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "exchange",
+    "inputs": [
+      {
+        "name": "i",
+        "type": "int128"
+      },
+      {
+        "name": "j",
+        "type": "int128"
+      },
+      {
+        "name": "dx",
+        "type": "uint256"
+      },
+      {
+        "name": "min_dy",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [],
+    "gas": 2816580
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "remove_liquidity",
+    "inputs": [
+      {
+        "name": "_amount",
+        "type": "uint256"
+      },
+      {
+        "name": "min_amounts",
+        "type": "uint256[3]"
+      }
+    ],
+    "outputs": [],
+    "gas": 192419
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "remove_liquidity_imbalance",
+    "inputs": [
+      {
+        "name": "amounts",
+        "type": "uint256[3]"
+      },
+      {
+        "name": "max_burn_amount",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [],
+    "gas": 6947760
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "calc_withdraw_one_coin",
+    "inputs": [
+      {
+        "name": "_token_amount",
+        "type": "uint256"
+      },
+      {
+        "name": "i",
+        "type": "int128"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "gas": 1162
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "remove_liquidity_one_coin",
+    "inputs": [
+      {
+        "name": "_token_amount",
+        "type": "uint256"
+      },
+      {
+        "name": "i",
+        "type": "int128"
+      },
+      {
+        "name": "min_amount",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [],
+    "gas": 4022793
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "ramp_A",
+    "inputs": [
+      {
+        "name": "_future_A",
+        "type": "uint256"
+      },
+      {
+        "name": "_future_time",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [],
+    "gas": 151582
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "stop_ramp_A",
+    "inputs": [],
+    "outputs": [],
+    "gas": 148300
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "commit_new_fee",
+    "inputs": [
+      {
+        "name": "new_fee",
+        "type": "uint256"
+      },
+      {
+        "name": "new_admin_fee",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [],
+    "gas": 110158
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "apply_new_fee",
+    "inputs": [],
+    "outputs": [],
+    "gas": 96939
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "revert_new_parameters",
+    "inputs": [],
+    "outputs": [],
+    "gas": 21592
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "commit_transfer_ownership",
+    "inputs": [
+      {
+        "name": "_owner",
+        "type": "address"
+      }
+    ],
+    "outputs": [],
+    "gas": 74330
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "apply_transfer_ownership",
+    "inputs": [],
+    "outputs": [],
+    "gas": 60407
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "revert_transfer_ownership",
+    "inputs": [],
+    "outputs": [],
+    "gas": 21682
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "admin_balances",
+    "inputs": [
+      {
+        "name": "i",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "gas": 3178
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "withdraw_admin_fees",
+    "inputs": [],
+    "outputs": [],
+    "gas": 28794
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "kill_me",
+    "inputs": [],
+    "outputs": [],
+    "gas": 37665
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "unkill_me",
+    "inputs": [],
+    "outputs": [],
+    "gas": 21802
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "coins",
+    "inputs": [
+      {
+        "name": "arg0",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "gas": 1887
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "balances",
+    "inputs": [
+      {
+        "name": "arg0",
+        "type": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "gas": 1917
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "fee",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "gas": 1838
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "admin_fee",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "gas": 1868
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "gas": 1898
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "fee_converter",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "gas": 1928
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "initial_A",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "gas": 1958
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "future_A",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "gas": 1988
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "initial_A_time",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "gas": 2018
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "future_A_time",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "gas": 2048
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "admin_actions_deadline",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "gas": 2078
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "transfer_ownership_deadline",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "gas": 2108
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "future_fee",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "gas": 2138
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "future_admin_fee",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "gas": 2168
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "future_owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "gas": 2198
+  }
+]

--- a/interfaces/nerve.json
+++ b/interfaces/nerve.json
@@ -1,0 +1,1035 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20[]",
+        "name": "_pooledTokens",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint8[]",
+        "name": "decimals",
+        "type": "uint8[]"
+      },
+      {
+        "internalType": "string",
+        "name": "lpTokenName",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "lpTokenSymbol",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_a",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_fee",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_adminFee",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_depositFee",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_withdrawFee",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_devaddr",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "tokenAmounts",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "fees",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "invariant",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "lpTokenSupply",
+        "type": "uint256"
+      }
+    ],
+    "name": "AddLiquidity",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newAdminFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "NewAdminFee",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newDepositFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "NewDepositFee",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newSwapFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "NewSwapFee",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newWithdrawFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "NewWithdrawFee",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Paused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldA",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newA",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "initialTime",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "futureTime",
+        "type": "uint256"
+      }
+    ],
+    "name": "RampA",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "tokenAmounts",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "lpTokenSupply",
+        "type": "uint256"
+      }
+    ],
+    "name": "RemoveLiquidity",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "tokenAmounts",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "fees",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "invariant",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "lpTokenSupply",
+        "type": "uint256"
+      }
+    ],
+    "name": "RemoveLiquidityImbalance",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "provider",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "lpTokenAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "lpTokenSupply",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "boughtId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokensBought",
+        "type": "uint256"
+      }
+    ],
+    "name": "RemoveLiquidityOne",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "currentA",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "time",
+        "type": "uint256"
+      }
+    ],
+    "name": "StopRampA",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "buyer",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokensSold",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokensBought",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "soldId",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "boughtId",
+        "type": "uint128"
+      }
+    ],
+    "name": "TokenSwap",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Unpaused",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minToMint",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "addLiquidity",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      }
+    ],
+    "name": "calculateCurrentWithdrawFee",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "calculateRemoveLiquidity",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "tokenIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "calculateRemoveLiquidityOneToken",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "availableTokenAmount",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "tokenIndexFrom",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint8",
+        "name": "tokenIndexTo",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "dx",
+        "type": "uint256"
+      }
+    ],
+    "name": "calculateSwap",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bool",
+        "name": "deposit",
+        "type": "bool"
+      }
+    ],
+    "name": "calculateTokenAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getA",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAPrecise",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "getAdminBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      }
+    ],
+    "name": "getDepositTimestamp",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "index",
+        "type": "uint8"
+      }
+    ],
+    "name": "getToken",
+    "outputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "index",
+        "type": "uint8"
+      }
+    ],
+    "name": "getTokenBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "tokenAddress",
+        "type": "address"
+      }
+    ],
+    "name": "getTokenIndex",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getVirtualPrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "futureA",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "futureTime",
+        "type": "uint256"
+      }
+    ],
+    "name": "rampA",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "minAmounts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "removeLiquidity",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxBurnAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "removeLiquidityImbalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "tokenIndex",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "removeLiquidityOneToken",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "newAdminFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "setAdminFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "newDepositFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "setDefaultDepositFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "newWithdrawFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "setDefaultWithdrawFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_devaddr",
+        "type": "address"
+      }
+    ],
+    "name": "setDevAddress",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "newSwapFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "setSwapFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "stopRampA",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "tokenIndexFrom",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint8",
+        "name": "tokenIndexTo",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "dx",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minDy",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "swap",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "swapStorage",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "initialA",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "futureA",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "initialATime",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "futureATime",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "swapFee",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "adminFee",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "defaultDepositFee",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "defaultWithdrawFee",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "devaddr",
+        "type": "address"
+      },
+      {
+        "internalType": "contract LPToken",
+        "name": "lpToken",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "unpause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "transferAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "updateUserWithdrawFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "withdrawAdminFees",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pytest~=6.2.3
 eth-brownie>=1.14.6
+rich~=10.2.0

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -1,0 +1,63 @@
+from brownie import *
+import time
+
+
+def e3p():
+    addr = "0x160CAed03795365F3A589f10C379FfA7d75d4E76"
+    coins = web3.toHex((web3.keccak(text="coins(uint256)")))[:10]
+    exchange = web3.toHex(
+        (web3.keccak(text="get_dy_underlying(int128,int128,uint256)"))
+    )[:10]
+
+    return {"addr": addr, "coins": coins, "exchange": exchange}
+
+
+def belt4p():
+    addr = "0xAEA4f7dcd172997947809CE6F12018a6D5c1E8b6"
+    coins = web3.toHex((web3.keccak(text="underlying_coins(int128)")))[:10]
+    exchange = web3.toHex(
+        (web3.keccak(text="get_dy_underlying(int128,int128,uint256)"))
+    )[:10]
+
+    return {"addr": addr, "coins": coins, "exchange": exchange}
+
+
+def nerve():
+    addr = "0x1B3771a66ee31180906972580adE9b81AFc5fCDc"
+    coins = web3.toHex((web3.keccak(text="getToken(uint8)")))[:10]
+    exchange = web3.toHex(
+        (web3.keccak(text="calculateSwap(uint8,uint8,uint256)"))
+    )[:10]
+
+    return {"addr": addr, "coins": coins, "exchange": exchange}
+
+
+def acs4p():
+    addr = "0xb3F0C9ea1F05e312093Fdb031E789A756659B0AC"
+    coins = web3.toHex((web3.keccak(text="coins(uint256)")))[:10]
+    exchange = web3.toHex(
+        (web3.keccak(text="get_dy(int128,int128,uint256)"))
+    )[:10]
+
+    return {"addr": addr, "coins": coins, "exchange": exchange}
+
+
+def dopple():
+    addr = "0x5162f992EDF7101637446ecCcD5943A9dcC63A8A"
+    coins = web3.toHex((web3.keccak(text="getToken(uint8)")))[:10]
+    exchange = web3.toHex(
+        (web3.keccak(text="calculateSwap(uint8,uint8,uint256)"))
+    )[:10]
+
+    return {"addr": addr, "coins": coins, "exchange": exchange}
+
+
+def main():
+    me = accounts.load('boobies')
+    accounts.default = me
+    s = Storage.deploy(publish_source=True)
+    o = OracleBSC.deploy(s.address, publish_source=True)
+    time.sleep(60)
+    for i in [e3p(), belt4p(), acs4p(), nerve(), dopple()]:
+        o.addStableSwapProvider(i["addr"], i["coins"], i["exchange"])
+    print(o.address)

--- a/test/test_stableoracle.py
+++ b/test/test_stableoracle.py
@@ -1,24 +1,70 @@
-import brownie.convert
+import brownie
+from brownie import web3
 import pytest
-from brownie import *
+from rich.console import Console
+
+console = Console()
 
 
 @pytest.fixture(scope="module")
 def e3p():
-    name = "e3p"
     addr = "0x160CAed03795365F3A589f10C379FfA7d75d4E76"
     coins = web3.toHex((web3.keccak(text="coins(uint256)")))[:10]
     exchange = web3.toHex(
         (web3.keccak(text="get_dy_underlying(int128,int128,uint256)"))
     )[:10]
 
-    yield {"name": name, "addr": addr, "coins": coins, "exchange": exchange}
+    yield {"addr": addr, "coins": coins, "exchange": exchange}
+
+
+@pytest.fixture(scope="module")
+def belt4p():
+    addr = "0xAEA4f7dcd172997947809CE6F12018a6D5c1E8b6"
+    coins = web3.toHex((web3.keccak(text="underlying_coins(int128)")))[:10]
+    exchange = web3.toHex(
+        (web3.keccak(text="get_dy_underlying(int128,int128,uint256)"))
+    )[:10]
+
+    yield {"addr": addr, "coins": coins, "exchange": exchange}
+
+
+@pytest.fixture(scope="module")
+def nerve():
+    addr = "0x1B3771a66ee31180906972580adE9b81AFc5fCDc"
+    coins = web3.toHex((web3.keccak(text="getToken(uint8)")))[:10]
+    exchange = web3.toHex(
+        (web3.keccak(text="calculateSwap(uint8,uint8,uint256)"))
+    )[:10]
+
+    yield {"addr": addr, "coins": coins, "exchange": exchange}
+
+
+@pytest.fixture(scope='module')
+def acs4p():
+    addr = "0xb3F0C9ea1F05e312093Fdb031E789A756659B0AC"
+    coins = web3.toHex((web3.keccak(text="coins(uint256)")))[:10]
+    exchange = web3.toHex(
+        (web3.keccak(text="get_dy(int128,int128,uint256)"))
+    )[:10]
+
+    yield {"addr": addr, "coins": coins, "exchange": exchange}
+
+
+@pytest.fixture(scope="module")
+def dopple():
+    addr = "0x5162f992EDF7101637446ecCcD5943A9dcC63A8A"
+    coins = web3.toHex((web3.keccak(text="getToken(uint8)")))[:10]
+    exchange = web3.toHex(
+        (web3.keccak(text="calculateSwap(uint8,uint8,uint256)"))
+    )[:10]
+
+    yield {"addr": addr, "coins": coins, "exchange": exchange}
+
 
 @pytest.fixture()
 def storage(Storage, accounts):
     accounts.default = accounts[0]
     yield Storage.deploy()
-
 
 
 @pytest.fixture()
@@ -31,17 +77,114 @@ def usdc():
     yield "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d"
 
 
+@pytest.fixture()
+def dai():
+    yield '0x1AF3F329e8BE154074D8769D1FFa4eE058B1DBc3'
+
+
+@pytest.fixture()
+def coins_3ps(e3p, interface):
+    c = interface.e3p(e3p['addr'])
+    yield [c.coins(0), c.coins(1), c.coins(2)]
+
+
+@pytest.fixture()
+def coins_belt(belt4p, interface):
+    c = interface.belt(belt4p['addr'])
+    yield [c.underlying_coins(0), c.underlying_coins(1), c.underlying_coins(2), c.underlying_coins(3)]
+
+
+@pytest.fixture()
+def coins_acs4p(acs4p, interface):
+    c = interface.e3p(acs4p['addr'])
+    yield [c.coins(0), c.coins(1), c.coins(2), c.coins(3)]
+
+
+@pytest.fixture()
+def coins_nerve(nerve, interface):
+    c = interface.nerve(nerve['addr'])
+    yield [c.getToken(0), c.getToken(1), c.getToken(2)]
+
+
+@pytest.fixture()
+def coins_dopple(dopple, interface):
+    c = interface.nerve(dopple['addr'])
+    yield [c.getToken(0), c.getToken(1), c.getToken(2), c.getToken(3)]
+
+
 @pytest.fixture(scope="function")
-def o(e3p, accounts, OracleBSC, storage):
+def o(e3p, belt4p, acs4p, nerve, dopple, accounts, OracleBSC, storage):
     accounts.default = accounts[0]
     o = OracleBSC.deploy(storage.address)
-    o.addStableSwapProvider(e3p["name"], e3p["addr"], e3p["coins"], e3p["exchange"])
+    for i in [e3p, belt4p, acs4p, nerve, dopple]:
+        o.addStableSwapProvider(i["addr"], i["coins"], i["exchange"])
     yield o
 
 
-def test_correct_add(o, e3p):
-    assert o.registry(e3p["name"])["name"] == e3p["name"]
+def test_add_to_registry(o, e3p, belt4p, acs4p, dopple, nerve):
+    for i in [e3p, belt4p, acs4p, dopple, nerve]:
+        assert o.registry(i["addr"])["addr"] == i["addr"]
+    assert len(o.getStableSwapProviders()) == 5
 
 
-def test_get_rate(o, e3p, busd, usdc):
-    assert o.getRate(e3p["name"], busd, usdc)[0]
+def test_get_coins(o, e3p):
+    a = o.getCoins(e3p['addr'])
+    print(a)
+
+
+def test_get_prices(o, coins_3ps, coins_belt, coins_acs4p, coins_nerve, coins_dopple, dopple, nerve, acs4p, e3p, belt4p,
+                    interface):
+    for coins, c, name in [[coins_3ps, interface.e3p(e3p['addr']), 'Ellipsis3Pool'],
+                           [coins_belt, interface.belt(belt4p['addr']), 'Belt4Pool'],
+                           [coins_acs4p, interface.e3p(acs4p['addr']), 'ACS4Pool'],
+                           [coins_nerve, interface.nerve(nerve['addr']), 'Nerve'],
+                           [coins_dopple, interface.nerve(dopple['addr']), 'Dopple']]:
+
+        console.print(f'\n')
+        console.rule(f'{name}')
+        for f in coins:
+            coins_ = coins.copy()
+            coins_.remove(f)
+            for s in coins_:
+                _f = interface.BEP20(f)
+                _s = interface.BEP20(s)
+                key0 = coins.index(f)
+                key1 = coins.index(s)
+                _fs = _f.symbol()
+                _ss = _s.symbol()
+
+                amount = 10 ** _f.decimals()
+
+                if name == 'Ellipsis3Pool' or name == 'Belt4Pool':
+                    check = c.get_dy_underlying(key0, key1, amount)
+                elif name == 'ACS4Pool':
+                    check = c.get_dy(key0, key1, amount)
+                elif name == 'Nerve' or name == 'Dopple':
+                    check = c.calculateSwap(key0, key1, amount)
+
+                result = o.getPriceStables(c.address, f, s)
+                console.print(
+                    f'Getting rates for {_fs} / {_ss}... {check / 1e18:.8f}(should) == {result[1] / 1e18:.8f}(is)')
+                assert check == result[1]
+                assert result[0]
+
+
+def test_get_prices_not_all_parameters(o, usdc, busd, e3p):
+    price = o.getPriceStables(e3p['addr'], usdc, busd)[1]
+    assert o.getPriceStables(e3p['addr'], usdc)[1] == price
+    assert o.getPriceStables(usdc)[1] == price
+
+
+def test_revert_wrong_coin(o, dai):
+    with brownie.reverts("couldn't find tokens in this exchange"):
+        o.getPriceStables(dai)
+
+
+def test_change_default_provider(o, belt4p):
+    assert o.changeDefaultProvider(belt4p['addr'])
+    assert o.defaultProvider() == belt4p['addr']
+
+
+def test_change_default_second_token(o, usdc):
+    assert o.changeDefaultSecondToken(usdc)
+    assert o.defaultSecondToken() == usdc


### PR DESCRIPTION
can be called from bsc oracle with

- getPriceStables(poolAddress, fromToken, toToken)
- getPriceStables(poolAddress, fromToken) - will use a default toToken (can be changed)
- getPriceStables(fromToken) - will use a default toToken, poolAddress (can be changed)

getStableSwapProviders() exposes an array of all the poolAddresses that are available,
getCoins(address _addr) lists an array with all token addresses that are in the given poolAddress

deployed at: 0x85773C069a9F205B2100e04c958F6Be8684C931C